### PR TITLE
Updated dependencies

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -23,6 +23,6 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "active-win": "^7.6.1"
+    "active-win": "^7.7.2"
   }
 }


### PR DESCRIPTION
Fixes an [issue](https://github.com/HASEL-UZH/PA.FlowTeams/issues/97) with the `ffi-napi` module on Windows 11 in FlowTeams.