### PR TITLE
fix: bypass TypeScript excess property check for timeout option

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -53,11 +53,12 @@ export class WindowsActivityTracker implements ITracker {
     const pollActiveWindow = () => {
       this.ref = setTimeout(async () => {
         try {
-          const res = await activeWindow({
+          const windowOptions = {
             accessibilityPermission: this.accessibilityPermission,
             screenRecordingPermission: this.screenRecordingPermission,
             timeout: ACTIVE_WINDOW_TIMEOUT_MS,
-          });
+          };
+          const res = await activeWindow(windowOptions);
           const window = {
             ts: new Date(),
             windowTitle: res?.title || undefined,


### PR DESCRIPTION
## Summary

- The `timeout` property added in #37 is not yet in `get-windows`' official `Options` type definition
- Passing it as a fresh object literal directly to `activeWindow()` triggers `TS2353: Object literal may only specify known properties`
- Using an intermediate variable bypasses TypeScript's excess property check via structural assignability — the object is identical at runtime

## Context

In projects where `get-windows` is hoisted to a parent `node_modules` (e.g. when used as a `file:` dependency in a monorepo), `patch-package` cannot find the local copy and the type patch in `patches/` is never applied. The intermediate variable approach fixes compilation without depending on the patch being applied first.

## Test plan

- [ ] `npm run build` passes without TS2353 error
