### PR TITLE
fix: make patch-package non-fatal when get-windows is hoisted

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -17,7 +17,7 @@
     "start": "npm run build && node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js --config jest.config.json",
     "prepare": "npm run build",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package || true"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

- When `windows-activity-tracker` is used as a `file:` dependency in a monorepo (e.g. PersonalAnalytics), npm hoists `get-windows` to the parent `node_modules`
- The submodule's `patch-package` postinstall then fails with: `Error: Patch file found for package get-windows which is not present at node_modules/get-windows`
- Adding `|| true` makes it non-fatal: the patch is applied when `get-windows` is installed locally (standalone use), and silently skipped when hoisted (the parent monorepo is expected to run `patch-package` itself)

## Test plan

- [ ] `npm install` succeeds when `get-windows` is hoisted to a parent `node_modules`
- [ ] Patch is still applied when installing `windows-activity-tracker` standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)